### PR TITLE
Track per-node card coverage in session tracker

### DIFF
--- a/analysis/session_tracker.py
+++ b/analysis/session_tracker.py
@@ -2,6 +2,7 @@
 
 import json
 import threading
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -21,6 +22,10 @@ class SessionCoverage:
     # Known IDs to bound coverage
     known_node_ids: set[str] = field(default_factory=set)
     known_card_ids: set[str] = field(default_factory=set)
+    # Node -> cards mapping and visit tracking
+    node_card_mapping: dict[str, set[str]] = field(default_factory=dict)
+    visited_cards_per_node: dict[str, set[str]] = field(default_factory=dict)
+    card_to_nodes: dict[str, set[str]] = field(default_factory=dict)
     
     def add_node(self, node_id: str):
         """Mark a node as visited."""
@@ -29,9 +34,61 @@ class SessionCoverage:
     
     def add_card(self, card_id: str):
         """Mark a card as visited."""
-        self.visited_cards.add(card_id)
-        self.card_visit_counts[card_id] = int(self.card_visit_counts.get(card_id, 0)) + 1
-    
+        cid = str(card_id)
+        self.visited_cards.add(cid)
+        self.card_visit_counts[cid] = int(self.card_visit_counts.get(cid, 0)) + 1
+
+    def register_node_cards(
+        self,
+        node_id: str,
+        card_ids: Iterable[str],
+        previously_visited: Iterable[str] | None = None,
+    ) -> None:
+        """Associate a node with its cards and retain past visits when possible."""
+
+        nid = str(node_id)
+        new_cards = {str(cid) for cid in card_ids if cid}
+
+        # Remove stale back-references before updating the mapping
+        old_cards = self.node_card_mapping.get(nid, set())
+        if old_cards:
+            removed = old_cards - new_cards
+            for cid in removed:
+                nodes = self.card_to_nodes.get(cid)
+                if nodes:
+                    nodes.discard(nid)
+                    if not nodes:
+                        self.card_to_nodes.pop(cid, None)
+
+        self.node_card_mapping[nid] = new_cards
+        for cid in new_cards:
+            self.card_to_nodes.setdefault(cid, set()).add(nid)
+
+        visited_seed = (
+            {str(cid) for cid in previously_visited if cid}
+            if previously_visited is not None
+            else set(self.visited_cards_per_node.get(nid, set()))
+        )
+        self.visited_cards_per_node[nid] = visited_seed & new_cards
+
+    def add_card_for_node(self, node_id: str, card_id: str) -> None:
+        """Record that a card associated with a node was visited."""
+
+        nid = str(node_id)
+        cid = str(card_id)
+        # Only track cards that are known to belong to the node
+        node_cards = self.node_card_mapping.get(nid)
+        if node_cards is not None and node_cards and cid not in node_cards:
+            return
+        if nid not in self.node_card_mapping:
+            return
+        self.visited_cards_per_node.setdefault(nid, set()).add(cid)
+
+    def get_nodes_for_card(self, card_id: str) -> set[str]:
+        """Return all nodes that reference the given card."""
+
+        return set(self.card_to_nodes.get(str(card_id), set()))
+
     def get_stats(self) -> dict[str, Any]:
         """Get coverage statistics bounded to known IDs to avoid >100%."""
         # Default totals
@@ -44,6 +101,19 @@ class SessionCoverage:
         def pct(a: int, b: int) -> float:
             return round((a / b * 100.0) if b else 0.0, 1)
         
+        per_node_card_coverage: dict[str, Any] = {}
+        for node_id, cards in self.node_card_mapping.items():
+            visited = self.visited_cards_per_node.get(node_id, set()) & cards
+            unvisited = cards - visited
+            per_node_card_coverage[node_id] = {
+                'card_ids': sorted(cards),
+                'visited_card_ids': sorted(visited),
+                'unvisited_card_ids': sorted(unvisited),
+                'visited': len(visited),
+                'total': len(cards),
+                'unvisited': len(unvisited),
+            }
+
         return {
             'nodes': {
                 'visited': nodes_visited,
@@ -57,7 +127,12 @@ class SessionCoverage:
             },
             'visited_node_ids': list(self.visited_nodes),
             'visited_card_ids': list(self.visited_cards),
-            'node_visit_counts': dict(self.node_visit_counts)
+            'node_visit_counts': dict(self.node_visit_counts),
+            'node_card_mapping': {nid: sorted(cards) for nid, cards in self.node_card_mapping.items()},
+            'visited_cards_per_node': {
+                nid: sorted(cards) for nid, cards in self.visited_cards_per_node.items()
+            },
+            'per_node_card_coverage': per_node_card_coverage,
         }
 
 
@@ -87,6 +162,29 @@ class SessionTracker:
             self.coverage.visited_cards = set(cov_data.get('visited_card_ids', []))
             self.coverage.total_nodes = cov_data.get('nodes', {}).get('total', 0)
             self.coverage.total_cards = cov_data.get('cards', {}).get('total', 0)
+            self.coverage.node_visit_counts = dict(cov_data.get('node_visit_counts', {}))
+
+            node_card_mapping_data: dict[str, Iterable[str]] = {
+                str(node_id): cards
+                for node_id, cards in (cov_data.get('node_card_mapping') or {}).items()
+            }
+            visited_cards_per_node_data: dict[str, Iterable[str]] = {
+                str(node_id): cards
+                for node_id, cards in (cov_data.get('visited_cards_per_node') or {}).items()
+            }
+            if not node_card_mapping_data and 'per_node_card_coverage' in cov_data:
+                for node_id, info in (cov_data.get('per_node_card_coverage') or {}).items():
+                    cards = info.get('card_ids') or []
+                    node_card_mapping_data[str(node_id)] = cards
+                    visited_cards_per_node_data.setdefault(
+                        str(node_id), info.get('visited_card_ids') or []
+                    )
+            for node_id, cards in node_card_mapping_data.items():
+                self.coverage.register_node_cards(
+                    node_id,
+                    cards or [],
+                    previously_visited=visited_cards_per_node_data.get(str(node_id), []),
+                )
     
     def _load_or_init(self) -> dict[str, Any]:
         """Load existing session or initialize new one."""
@@ -121,78 +219,289 @@ class SessionTracker:
     
     def initialize_coverage(self, graphs_dir: Path, manifest_dir: Path):
         """Initialize coverage tracking by counting total nodes and cards.
-        
+
         Args:
             graphs_dir: Directory containing graph files
             manifest_dir: Directory containing manifest files
         """
-        # Count nodes from graphs and record known IDs
+        known_node_ids: set[str] = set()
+        node_card_map: dict[str, set[str]] = {}
+        referenced_card_ids: set[str] = set()
         total_nodes = 0
+
         if graphs_dir.exists():
             for graph_file in graphs_dir.glob("graph_*.json"):
                 try:
                     with open(graph_file) as f:
                         graph_data = json.load(f)
-                        nodes = graph_data.get('nodes', [])
-                        total_nodes += len(nodes)
-                        for n in nodes or []:
-                            nid = n.get('id')
-                            if nid is not None:
-                                self.coverage.known_node_ids.add(str(nid))
                 except Exception:
-                    pass
-        
-        # Count cards from manifest
-        total_cards = 0
+                    continue
+
+                nodes = graph_data.get('nodes', []) or []
+                total_nodes += len(nodes)
+
+                for node in nodes:
+                    if not isinstance(node, dict):
+                        continue
+                    nid = node.get('id')
+                    if nid is None:
+                        continue
+
+                    nid_str = str(nid)
+                    known_node_ids.add(nid_str)
+
+                    refs = node.get('source_refs') or node.get('refs') or []
+                    node_cards = node_card_map.setdefault(nid_str, set())
+                    for ref in refs:
+                        card_id: str | None = None
+                        if isinstance(ref, str):
+                            card_id = ref
+                        elif isinstance(ref, dict):
+                            card_id = (
+                                ref.get('card_id')
+                                or ref.get('id')
+                                or ref.get('card')
+                                or ref.get('cardId')
+                            )
+                            if not card_id:
+                                value = ref.get('value')
+                                if isinstance(value, str):
+                                    card_id = value
+                        if card_id:
+                            cid = str(card_id)
+                            node_cards.add(cid)
+                            referenced_card_ids.add(cid)
+
         manifest_file = manifest_dir / "manifest.json" if manifest_dir.exists() else None
+        total_cards = 0
+        self._repo_root = None
         if manifest_file and manifest_file.exists():
             try:
                 with open(manifest_file) as f:
                     manifest_data = json.load(f)
-                    # Try both formats - num_cards or files array
-                    if 'num_cards' in manifest_data:
-                        total_cards = manifest_data['num_cards']
-                    elif 'files' in manifest_data:
-                        total_cards = len(manifest_data['files'])
             except Exception:
-                pass
-        
-        # Build known card IDs and file->cards mapping for accurate tracking
-        try:
-            self._file_to_cards: dict[str, list[str]] = {}
-            cards_jsonl = manifest_dir / 'cards.jsonl'
-            if cards_jsonl.exists():
+                manifest_data = None
+            if isinstance(manifest_data, dict):
+                num_cards = manifest_data.get('num_cards')
+                files_list = manifest_data.get('files')
+                if isinstance(num_cards, int):
+                    total_cards = num_cards
+                elif isinstance(files_list, list):
+                    total_cards = len(files_list)
+
+                repo_root = manifest_data.get('repository')
+                if isinstance(repo_root, str):
+                    self._repo_root = repo_root
+
+        self._file_to_cards: dict[str, set[str]] = {}
+        card_store_ids: set[str] = set()
+
+        cards_jsonl = manifest_dir / 'cards.jsonl'
+        if cards_jsonl.exists():
+            try:
                 with open(cards_jsonl) as f:
                     for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
                         try:
                             card = json.loads(line)
-                            cid = card.get('id')
-                            rel = card.get('relpath')
-                            if cid:
-                                self.coverage.known_card_ids.add(str(cid))
-                            if rel and cid:
-                                self._file_to_cards.setdefault(rel, []).append(str(cid))
                         except Exception:
                             continue
-            files_json = manifest_dir / 'files.json'
-            if files_json.exists():
+                        if not isinstance(card, dict):
+                            continue
+                        cid = card.get('id')
+                        cid_str = str(cid) if cid else None
+                        if cid_str:
+                            card_store_ids.add(cid_str)
+                        rel_candidates = []
+                        rel = card.get('relpath') or card.get('path')
+                        if rel:
+                            rel_candidates.append(rel)
+                        metadata = card.get('metadata') or {}
+                        if isinstance(metadata, dict):
+                            rel_meta = metadata.get('relpath') or metadata.get('path')
+                            if rel_meta:
+                                rel_candidates.append(rel_meta)
+                        if cid_str:
+                            for rel_value in rel_candidates:
+                                self._index_file_to_card(rel_value, cid_str)
+            except Exception:
+                pass
+
+        files_json = manifest_dir / 'files.json'
+        if files_json.exists():
+            try:
                 with open(files_json) as f:
                     files_list = json.load(f)
-                if isinstance(files_list, list):
-                    for fi in files_list:
-                        rel = fi.get('relpath')
-                        cids = fi.get('card_ids', []) or []
-                        if rel and cids:
-                            self._file_to_cards[rel] = [str(x) for x in cids]
-                            for x in cids:
-                                self.coverage.known_card_ids.add(str(x))
+            except Exception:
+                files_list = None
+            if isinstance(files_list, list):
+                for entry in files_list:
+                    if not isinstance(entry, dict):
+                        continue
+                    rel = entry.get('relpath') or entry.get('path')
+                    cids = entry.get('card_ids', []) or []
+                    for cid in cids:
+                        cid_str = str(cid)
+                        card_store_ids.add(cid_str)
+                        if rel:
+                            self._index_file_to_card(rel, cid_str)
+
+        known_card_ids = referenced_card_ids | card_store_ids
+
+        previous_visits = {
+            node_id: set(cards)
+            for node_id, cards in self.coverage.visited_cards_per_node.items()
+        }
+        self.coverage.node_card_mapping = {}
+        self.coverage.card_to_nodes = {}
+        self.coverage.visited_cards_per_node = {}
+
+        all_node_ids = set(node_card_map.keys()) | known_node_ids
+        for node_id in all_node_ids:
+            cards = node_card_map.get(node_id, set())
+            previously_visited = previous_visits.get(node_id, set())
+            self.coverage.register_node_cards(
+                node_id,
+                cards,
+                previously_visited=previously_visited,
+            )
+
+        self.coverage.known_node_ids = known_node_ids
+        self.coverage.known_card_ids = known_card_ids
+        self.coverage.total_nodes = total_nodes
+        self.coverage.total_cards = max(total_cards, len(known_card_ids))
+        self._save()
+
+    def _index_file_to_card(self, relpath: str | Path, card_id: str) -> None:
+        """Index a card ID by a variety of path representations."""
+
+        if not relpath or not card_id:
+            return
+
+        path_str = str(relpath)
+        cid = str(card_id)
+        if not path_str or not cid:
+            return
+
+        mapping = getattr(self, '_file_to_cards', None)
+        if mapping is None:
+            self._file_to_cards = {}
+            mapping = self._file_to_cards
+
+        variants: set[str] = set()
+        normalized = path_str.replace('\\', '/')
+        variants.update({path_str, normalized})
+
+        for candidate in list(variants):
+            variants.add(candidate.lstrip('/'))
+            variants.add(candidate.lstrip('./'))
+
+        try:
+            posix = Path(path_str).as_posix()
+            variants.update({posix, posix.lstrip('/'), posix.lstrip('./')})
         except Exception:
             pass
 
-        self.coverage.total_nodes = total_nodes
-        self.coverage.total_cards = total_cards
-        self._save()
-    
+        repo_root = getattr(self, '_repo_root', None)
+        if repo_root:
+            try:
+                repo_root_path = Path(repo_root)
+                rel_path = Path(path_str)
+                if rel_path.is_absolute():
+                    try:
+                        rel_to_root = rel_path.relative_to(repo_root_path)
+                        rel_posix = rel_to_root.as_posix()
+                        variants.update({rel_posix, rel_posix.lstrip('/'), rel_posix.lstrip('./')})
+                    except Exception:
+                        pass
+                else:
+                    abs_path = (repo_root_path / rel_path).resolve()
+                    variants.add(abs_path.as_posix())
+            except Exception:
+                pass
+
+        for key in {v for v in variants if v}:
+            bucket = mapping.setdefault(key, set())
+            bucket.add(cid)
+
+    def _candidate_card_keys(self, identifier: str) -> set[str]:
+        """Return possible lookup keys for a card identifier or path."""
+
+        if identifier is None:
+            return set()
+
+        value = str(identifier)
+        if not value:
+            return set()
+
+        variants: set[str] = {value, value.lstrip('./')}
+        normalized = value.replace('\\', '/')
+        variants.update({normalized, normalized.lstrip('/'), normalized.lstrip('./')})
+
+        try:
+            posix = Path(value).as_posix()
+            variants.update({posix, posix.lstrip('/'), posix.lstrip('./')})
+        except Exception:
+            pass
+
+        repo_root = getattr(self, '_repo_root', None)
+        if repo_root:
+            try:
+                repo_root_path = Path(repo_root)
+                value_path = Path(value)
+                if value_path.is_absolute():
+                    try:
+                        rel = value_path.relative_to(repo_root_path)
+                        rel_posix = rel.as_posix()
+                        variants.update({rel_posix, rel_posix.lstrip('/'), rel_posix.lstrip('./')})
+                    except Exception:
+                        pass
+                else:
+                    abs_posix = (repo_root_path / value_path).resolve().as_posix()
+                    variants.add(abs_posix)
+            except Exception:
+                pass
+
+        return {v for v in variants if v}
+
+    def _resolve_card_ids(self, identifier: str) -> set[str]:
+        """Resolve a card identifier or path to known card IDs."""
+
+        if identifier is None:
+            return set()
+
+        ident = str(identifier)
+        resolved: set[str] = set()
+
+        if ident in self.coverage.known_card_ids or ident in self.coverage.card_to_nodes:
+            resolved.add(ident)
+
+        mapping = getattr(self, '_file_to_cards', None)
+        if mapping:
+            for key in self._candidate_card_keys(ident):
+                cards = mapping.get(key)
+                if cards:
+                    resolved.update(cards)
+
+        return resolved
+
+    def _record_card_visits(self, identifiers: Iterable[str]) -> None:
+        """Apply visit tracking for one or more card identifiers."""
+
+        for identifier in identifiers:
+            if identifier is None:
+                continue
+            resolved_ids = self._resolve_card_ids(identifier)
+            if resolved_ids:
+                for cid in resolved_ids:
+                    self.coverage.add_card(cid)
+                    for node_id in self.coverage.get_nodes_for_card(cid):
+                        self.coverage.add_card_for_node(node_id, cid)
+            else:
+                self.coverage.add_card(str(identifier))
+
     def track_node_visit(self, node_id: str):
         """Track that a node was visited during investigation."""
         with self.lock:
@@ -202,27 +511,7 @@ class SessionTracker:
     def track_card_visit(self, card_path: str):
         """Track that a code card was analyzed."""
         with self.lock:
-            # Try to map file path to card IDs for accurate card coverage
-            ids: list[str] = []
-            try:
-                # Normalize path to relpath if possible
-                rel = card_path
-                # If the provided path is absolute or has prefixes, try to use as-is in mapping first
-                if hasattr(self, '_file_to_cards'):
-                    if rel in self._file_to_cards:
-                        ids = list(self._file_to_cards.get(rel, []))
-                    else:
-                        # Try stripping leading slashes
-                        rel2 = rel.lstrip('/')
-                        ids = list(self._file_to_cards.get(rel2, []))
-            except Exception:
-                ids = []
-            if ids:
-                for cid in ids:
-                    self.coverage.add_card(cid)
-            else:
-                # Fall back to recording the path (won't count toward known cards)
-                self.coverage.add_card(card_path)
+            self._record_card_visits([card_path])
             self._save()
     
     def track_nodes_batch(self, node_ids: list[str]):
@@ -235,8 +524,7 @@ class SessionTracker:
     def track_cards_batch(self, card_paths: list[str]):
         """Track multiple cards analyzed at once."""
         with self.lock:
-            for card_path in card_paths:
-                self.coverage.add_card(card_path)
+            self._record_card_visits(card_paths)
             self._save()
     
     def add_investigation(self, investigation: dict[str, Any]):

--- a/tests/test_session_tracker.py
+++ b/tests/test_session_tracker.py
@@ -1,0 +1,92 @@
+"""Tests for session tracker coverage mapping and card tracking."""
+
+import json
+from pathlib import Path
+
+from analysis.session_tracker import SessionTracker
+
+
+def _create_test_environment(tmp_path: Path):
+    session_dir = tmp_path / "session"
+    graphs_dir = tmp_path / "graphs"
+    manifest_dir = tmp_path / "manifest"
+    repo_root = tmp_path / "repo"
+
+    graphs_dir.mkdir(parents=True)
+    manifest_dir.mkdir(parents=True)
+    (repo_root / "src/module").mkdir(parents=True)
+
+    graph_data = {
+        "nodes": [
+            {"id": "node_a", "source_refs": ["card1", "card2"]},
+            {"id": "node_b", "source_refs": ["card2"]},
+        ]
+    }
+    with open(graphs_dir / "graph_test.json", "w") as f:
+        json.dump(graph_data, f)
+
+    manifest_data = {"repository": str(repo_root), "num_cards": 2}
+    with open(manifest_dir / "manifest.json", "w") as f:
+        json.dump(manifest_data, f)
+
+    cards = [
+        {"id": "card1", "relpath": "src/module/file1.sol"},
+        {"id": "card2", "relpath": "src/module/file2.sol"},
+    ]
+    with open(manifest_dir / "cards.jsonl", "w") as f:
+        for card in cards:
+            f.write(json.dumps(card) + "\n")
+
+    return session_dir, graphs_dir, manifest_dir, repo_root
+
+
+def test_session_tracker_per_node_card_coverage(tmp_path):
+    session_dir, graphs_dir, manifest_dir, repo_root = _create_test_environment(tmp_path)
+
+    tracker = SessionTracker(session_dir, "session")
+    tracker.initialize_coverage(graphs_dir, manifest_dir)
+
+    assert tracker.coverage.node_card_mapping["node_a"] == {"card1", "card2"}
+    assert tracker.coverage.node_card_mapping["node_b"] == {"card2"}
+    assert tracker.coverage.card_to_nodes["card2"] == {"node_a", "node_b"}
+
+    tracker.track_card_visit(str(repo_root / "src/module/file1.sol"))
+
+    stats = tracker.get_coverage_stats()
+    assert stats["cards"]["visited"] == 1
+    assert stats["per_node_card_coverage"]["node_a"]["visited"] == 1
+    assert stats["per_node_card_coverage"]["node_a"]["unvisited_card_ids"] == ["card2"]
+    assert stats["per_node_card_coverage"]["node_b"]["visited"] == 0
+    assert stats["visited_cards_per_node"]["node_a"] == ["card1"]
+    assert stats["visited_cards_per_node"]["node_b"] == []
+
+    tracker.initialize_coverage(graphs_dir, manifest_dir)
+    assert tracker.coverage.visited_cards_per_node["node_a"] == {"card1"}
+
+    tracker.track_card_visit("card2")
+
+    stats = tracker.get_coverage_stats()
+    assert set(stats["visited_card_ids"]) == {"card1", "card2"}
+    assert stats["per_node_card_coverage"]["node_a"]["visited"] == 2
+    assert stats["per_node_card_coverage"]["node_a"]["unvisited"] == 0
+    assert stats["per_node_card_coverage"]["node_b"]["visited"] == 1
+    assert stats["visited_cards_per_node"]["node_b"] == ["card2"]
+
+
+def test_track_cards_batch_maps_paths_and_ids(tmp_path):
+    session_dir, graphs_dir, manifest_dir, repo_root = _create_test_environment(tmp_path)
+
+    tracker = SessionTracker(session_dir, "batch")
+    tracker.initialize_coverage(graphs_dir, manifest_dir)
+
+    tracker.track_cards_batch([
+        "src/module/file1.sol",
+        str((repo_root / "src/module/file2.sol").resolve()),
+    ])
+
+    stats = tracker.get_coverage_stats()
+    assert stats["cards"]["visited"] == 2
+    assert stats["per_node_card_coverage"]["node_a"]["visited"] == 2
+    assert stats["per_node_card_coverage"]["node_b"]["visited"] == 1
+    assert tracker.coverage.visited_cards_per_node["node_a"] == {"card1", "card2"}
+    assert tracker.coverage.visited_cards_per_node["node_b"] == {"card2"}


### PR DESCRIPTION
## Summary
- extend session coverage with node-to-card mapping, per-node visit tracking, and richer stats output
- build the node/card index when initializing coverage and resolve card paths back to owning nodes when recording visits
- add regression tests covering per-node card coverage and mixed path/id batch tracking

## Testing
- `pytest tests/test_session_tracker.py`
- `ruff check analysis/session_tracker.py tests/test_session_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_68ce19676c688325bf2aceaede482b90