### PR TITLE
Add glob-aware file include and ignore filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Recommended (one‑liner):
 
 ```bash
 # Auto-generate a default set of graphs (up to 5) and refine
-# Strongly recommended: pass a whitelist of files (comma-separated)
+# Strongly recommended: pass a whitelist of files (comma-separated, glob patterns supported)
 ./hound.py graph build myaudit --auto \
   --files "src/A.sol,src/B.sol,src/utils/Lib.sol"
 
@@ -121,7 +121,8 @@ Alternative (manual guidance):
 ./hound.py graph custom myaudit \
   "Call graph focusing on function call relationships across modules" \
   --iterations 2 \
-  --files "src/A.sol,src/B.sol,src/utils/Lib.sol"
+  --files "src/A.sol,src/B.sol,src/utils/Lib.sol" \
+  --ignore "tests/**/*.sol"
 
 # (Repeat 'graph custom' for additional targeted graphs as needed)
 ```
@@ -142,7 +143,8 @@ Whitelists (strongly recommended):
 
 - Always pass a whitelist of input files via `--files`. For the best results, the selected files should fit in the model’s available context window; whitelisting keeps the graph builder focused and avoids token overflows.
 - If you do not pass `--files`, Hound will consider all files in the repository. On large codebases this triggers sampling and may degrade coverage/quality.
-- `--files` expects a comma‑separated list of paths relative to the repo root.
+- `--files` expects a comma‑separated list of paths relative to the repo root. Glob patterns (e.g., `src/**/*.sol`) are supported.
+- Use `--ignore` to exclude paths that match comma‑separated glob patterns (e.g., generated code or tests).
 
 Examples:
 

--- a/hound.py
+++ b/hound.py
@@ -562,7 +562,8 @@ def graph_build(
     iterations: int = typer.Option(3, "--iterations", "-i", help="Maximum iterations for graph refinement"),
     graphs: int = typer.Option(5, "--graphs", "-g", help="Number of graphs to generate (ignored if --graph-spec is set)"),
     focus: str = typer.Option(None, "--focus", "-f", help="Comma-separated focus areas"),
-    files: str = typer.Option(None, "--files", help="Comma-separated list of file paths to include"),
+    files: str = typer.Option(None, "--files", help="Comma-separated list of file paths to include (supports glob patterns)"),
+    ignore: str = typer.Option(None, "--ignore", help="Comma-separated glob patterns to exclude"),
     with_spec: str = typer.Option(None, "--with-spec", help="Build exactly one graph described by this text (skips discovery for others)"),
     graph_spec: str = typer.Option(None, "--graph-spec", help="[Deprecated] Same as --with-spec"),
     refine_existing: bool = typer.Option(True, "--refine-existing/--no-refine-existing", help="Load and refine existing graphs in the project directory"),
@@ -624,6 +625,7 @@ def graph_build(
         max_graphs=graphs,
         focus_areas=focus,
         file_filter=files,
+        ignore_filter=ignore,
         with_spec=_spec,
         graph_spec=None,
         refine_existing=refine_existing,
@@ -640,7 +642,8 @@ def graph_build(
 def graph_ingest(
     target: str = typer.Argument(..., help="Project name or repository path"),
     config: str | None = typer.Option(None, "--config", "-c", help="Configuration file"),
-    files: str | None = typer.Option(None, "--files", "-f", help="Comma-separated file paths to include"),
+    files: str | None = typer.Option(None, "--files", "-f", help="Comma-separated file paths to include (supports glob patterns)"),
+    ignore: str | None = typer.Option(None, "--ignore", "-x", help="Comma-separated glob patterns to exclude"),
     manual_chunking: bool = typer.Option(False, "--manual-chunking", help="Split files using manual markers instead of automatic chunking"),
     debug: bool = typer.Option(False, "--debug", "-d", help="Enable debug output")
 ):
@@ -673,6 +676,7 @@ def graph_ingest(
         output_dir=str(output_dir),
         config_path=Path(config) if config else None,
         file_filter=files,
+        ignore_filter=ignore,
         manual_chunking=manual_chunking,
         debug=debug
     )
@@ -682,7 +686,8 @@ def graph_custom(
     project: str = typer.Argument(..., help="Project name"),
     spec: str = typer.Argument(..., help="Natural language description of the desired graph"),
     iterations: int = typer.Option(3, "--iterations", "-i", help="Refinement iterations"),
-    files: str = typer.Option(None, "--files", help="Comma-separated list of file paths to include"),
+    files: str = typer.Option(None, "--files", help="Comma-separated list of file paths to include (supports glob patterns)"),
+    ignore: str = typer.Option(None, "--ignore", help="Comma-separated glob patterns to exclude"),
     config: str = typer.Option(None, "--config", "-c", help="Configuration file"),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Reduce output"),
     debug: bool = typer.Option(False, "--debug", "-d", help="Enable debug output"),
@@ -699,6 +704,7 @@ def graph_custom(
         config_path=Path(config) if config else None,
         iterations=iterations,
         file_filter=files,
+        ignore_filter=ignore,
         reuse_ingestion=True,
         debug=debug,
         quiet=quiet,
@@ -710,7 +716,8 @@ def graph_refine(
     name: str = typer.Argument(None, help="Graph name to refine (internal or display name)"),
     all: bool = typer.Option(False, "--all", help="Refine all existing graphs"),
     iterations: int = typer.Option(3, "--iterations", "-i", help="Maximum refinement iterations"),
-    files: str = typer.Option(None, "--files", help="Comma-separated list of file paths to include"),
+    files: str = typer.Option(None, "--files", help="Comma-separated list of file paths to include (supports glob patterns)"),
+    ignore: str = typer.Option(None, "--ignore", help="Comma-separated glob patterns to exclude"),
     config: str = typer.Option(None, "--config", "-c", help="Configuration file"),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Reduce output"),
     debug: bool = typer.Option(False, "--debug", "-d", help="Enable debug output")
@@ -737,6 +744,7 @@ def graph_refine(
         max_graphs=1,
         focus_areas=None,
         file_filter=files,
+        ignore_filter=ignore,
         graph_spec=None,
         refine_existing=True,
         init=False,

--- a/tests/test_manifest_filters.py
+++ b/tests/test_manifest_filters.py
@@ -1,0 +1,68 @@
+"""Tests for include/ignore pattern handling in RepositoryManifest."""
+
+from pathlib import Path
+
+from ingest.manifest import RepositoryManifest, normalize_patterns
+
+
+def _write_file(path: Path, content: str = "print('hello world')\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_normalize_patterns_deduplicates_and_strips() -> None:
+    patterns = normalize_patterns([" ./src/app.py ", "./src/app.py", "src/app.py", None, ""])
+    assert patterns == ["src/app.py"]
+
+
+def test_repository_manifest_glob_includes(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_file(repo / "src" / "module" / "app.py")
+    _write_file(repo / "src" / "module" / "helper.py")
+    _write_file(repo / "tests" / "test_app.py")
+
+    manifest = RepositoryManifest(
+        str(repo),
+        config={"file_extensions": [".py"]},
+        file_filter=["src/**/*.py"],
+    )
+
+    _cards, files = manifest.walk_repository()
+    relpaths = sorted(Path(f.relpath).as_posix() for f in files)
+    assert relpaths == ["src/module/app.py", "src/module/helper.py"]
+
+
+def test_repository_manifest_ignore_patterns(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_file(repo / "src" / "module" / "app.py")
+    _write_file(repo / "src" / "module" / "helper.py")
+    _write_file(repo / "tests" / "test_app.py")
+    _write_file(repo / "src" / "module" / "utils" / "tool.py")
+
+    manifest = RepositoryManifest(
+        str(repo),
+        config={"file_extensions": [".py"]},
+        ignore_patterns=["tests/**/*.py", "src/**/utils/*.py"],
+    )
+
+    _cards, files = manifest.walk_repository()
+    relpaths = sorted(Path(f.relpath).as_posix() for f in files)
+    assert relpaths == ["src/module/app.py", "src/module/helper.py"]
+
+
+def test_repository_manifest_include_and_ignore(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _write_file(repo / "src" / "module" / "app.py")
+    _write_file(repo / "src" / "module" / "utils" / "tool.py")
+    _write_file(repo / "tests" / "test_app.py")
+
+    manifest = RepositoryManifest(
+        str(repo),
+        config={"file_extensions": [".py"]},
+        file_filter=["src/**/*.py", "tests/**/*.py"],
+        ignore_patterns=["**/utils/*.py"],
+    )
+
+    _cards, files = manifest.walk_repository()
+    relpaths = sorted(Path(f.relpath).as_posix() for f in files)
+    assert relpaths == ["src/module/app.py", "tests/test_app.py"]


### PR DESCRIPTION
## Summary
- add glob-aware parsing for `--files` and a new `--ignore` option across graph CLI commands
- extend the repository manifest to normalize include/ignore patterns and persist ignore metadata
- document the new filters and cover their behavior with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce2152e62c83259670a5f22c6ec688