### PR TITLE
Improve report metadata loading and coverage stats

### DIFF
--- a/tests/test_coverage_index.py
+++ b/tests/test_coverage_index.py
@@ -1,0 +1,37 @@
+"""Tests for CoverageIndex utility methods."""
+
+from __future__ import annotations
+
+import json
+
+from analysis.coverage_index import CoverageIndex
+
+
+def test_compute_stats_streams_jsonl(tmp_path):
+    graphs_dir = tmp_path / "graphs"
+    manifest_dir = tmp_path / "manifest"
+    graphs_dir.mkdir()
+    manifest_dir.mkdir()
+
+    (graphs_dir / "graph_Test.json").write_text(json.dumps({
+        "nodes": [
+            {"id": "n1"},
+            {"id": "n2"},
+        ]
+    }))
+
+    cards_path = manifest_dir / "cards.jsonl"
+    with cards_path.open("w", encoding="utf-8") as fh:
+        for cid in ("card-1", "card-2", "card-3"):
+            fh.write(json.dumps({"id": cid}) + "\n")
+
+    cov = CoverageIndex(tmp_path / "coverage_index.json", agent_id="tester")
+    cov.touch_node("n1")
+    cov.touch_card("card-2")
+
+    stats = cov.compute_stats(graphs_dir, manifest_dir)
+
+    assert stats["nodes"]["total"] == 2
+    assert stats["nodes"]["visited"] == 1
+    assert stats["cards"]["total"] == 3
+    assert stats["cards"]["visited"] == 1

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -52,3 +52,21 @@ class TestReportGenerator(unittest.TestCase):
             self.assertIn('Proj', html)
             self.assertIn('Findings', html)
             self.assertIn('System Overview', html)
+
+    def test_loads_relative_card_store_and_repo_root(self):
+        graphs_dir = self.tmp / 'graphs'
+        (graphs_dir / 'card_store.json').write_text(json.dumps({'card-1': {'content': 'data'}}))
+        (graphs_dir / 'knowledge_graphs.json').write_text(json.dumps({
+            'card_store_path': 'card_store.json',
+            'manifest': {'repo_path': 'repo_root'}
+        }))
+        (self.tmp / 'repo_root').mkdir()
+
+        cfg = {'models': {'reporting': {'provider': 'openai', 'model': 'x'}}}
+        with patch('analysis.report_generator.UnifiedLLMClient') as MockLLM:
+            mock_client = MagicMock()
+            MockLLM.return_value = mock_client
+            rg = ReportGenerator(self.tmp, cfg)
+
+        self.assertEqual(rg.card_store, {'card-1': {'content': 'data'}})
+        self.assertEqual(rg.repo_root, (self.tmp / 'repo_root').resolve())


### PR DESCRIPTION
## Summary
- make the report generator resilient to projects moved between machines by resolving relative card store and repository paths
- avoid loading large coverage files into memory by streaming graph and card metadata when computing stats
- add regression tests covering the new path handling and coverage statistics logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ce34d5fe048325b17613493428a36a