### PR TITLE
Improve empty manifest guidance

### DIFF
--- a/commands/graph.py
+++ b/commands/graph.py
@@ -286,6 +286,14 @@ def build(
                     ignore_patterns=ignore_patterns,
                 )
                 cards, files = manifest.walk_repository()
+                if not files:
+                    console.print(
+                        f"[red]Error: Repository manifest contained no files under {repo_path}.[/red]"
+                    )
+                    console.print(
+                        "[yellow]Tip: Check or update the project's source_path if the repository moved or is empty.[/yellow]"
+                    )
+                    raise typer.Exit(code=2)
                 manifest.save_manifest(manifest_dir)
                 log_line('ingest', f"Ingested {len(files)} files → {len(cards)} cards")
                 bundler = AdaptiveBundler(cards, files, config)
@@ -654,6 +662,14 @@ def custom(
             ignore_patterns=ignore_patterns,
         )
         cards, files = manifest.walk_repository()
+        if not files:
+            console.print(
+                f"[red]Error: Repository manifest contained no files under {repo_root}.[/red]"
+            )
+            console.print(
+                "[yellow]Tip: Check or update the project's source_path if the repository moved or is empty.[/yellow]"
+            )
+            raise typer.Exit(code=2)
         manifest.save_manifest(manifest_dir)
         bundler = AdaptiveBundler(cards, files, config)
         bundler.create_bundles()

--- a/tests/commands/test_graph_build_no_files.py
+++ b/tests/commands/test_graph_build_no_files.py
@@ -1,0 +1,69 @@
+"""Tests for graph build CLI handling when ingestion finds no files."""
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import typer
+
+from commands import graph as graph_cmd
+
+
+class TestGraphBuildNoFiles(unittest.TestCase):
+    """Ensure the graph build command provides actionable guidance when empty."""
+
+    def setUp(self) -> None:
+        self.temp_home = Path(tempfile.mkdtemp())
+        self.projects_root = self.temp_home / ".hound" / "projects"
+        self.project_id = "emptyproj"
+        self.project_dir = self.projects_root / self.project_id
+        self.repo_path = self.temp_home / "repo"
+
+        self.repo_path.mkdir(parents=True, exist_ok=True)
+        self.project_dir.mkdir(parents=True, exist_ok=True)
+
+        project_config = {"source_path": str(self.repo_path)}
+        (self.project_dir / "project.json").write_text(json.dumps(project_config))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.temp_home, ignore_errors=True)
+
+    @patch("commands.graph.RepositoryManifest.walk_repository", return_value=([], []))
+    @patch("commands.graph.load_config", return_value={})
+    def test_empty_manifest_prompts_source_path_check(self, _load_config, _walk_repo):
+        """An empty manifest should mention the repo path and source_path guidance."""
+        with patch("pathlib.Path.home", return_value=self.temp_home):
+            with patch.object(graph_cmd.console, "print") as mock_print:
+                with self.assertRaises(typer.Exit) as exit_ctx:
+                    graph_cmd.build(
+                        self.project_id,
+                        file_filter=None,
+                        ignore_filter=None,
+                        with_spec=None,
+                        graph_spec=None,
+                        refine_existing=False,
+                    )
+
+        self.assertEqual(exit_ctx.exception.exit_code, 2)
+
+        rendered = [
+            " ".join(str(arg) for arg in call.args)
+            for call in mock_print.call_args_list
+        ]
+
+        resolved_repo = str(self.repo_path.resolve())
+        self.assertTrue(
+            any(resolved_repo in message for message in rendered),
+            "Expected error output to include the resolved repository path.",
+        )
+        self.assertTrue(
+            any("source_path" in message for message in rendered),
+            "Expected guidance to explicitly mention checking the project's source_path.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update the graph build and custom ingestion flows to surface the resolved repository path when no files are ingested
- advise users to verify the project source_path and add coverage for the new guidance messaging

## Testing
- pytest tests/commands/test_graph_build_no_files.py

------
https://chatgpt.com/codex/tasks/task_e_68d4b962500483258da1694cdf26c081