### PR TITLE
Add project set-source command and helper

### DIFF
--- a/hound.py
+++ b/hound.py
@@ -185,6 +185,17 @@ def project_delete(
     from commands.project import delete
     _invoke_click(delete, {'name': name, 'force': force})
 
+
+@project_app.command("set-source")
+def project_set_source(
+    name: str = typer.Argument(..., help="Project name"),
+    source_path: str = typer.Argument(..., help="New source path")
+):
+    """Update a project's source path."""
+
+    from commands.project import set_source
+    _invoke_click(set_source, {'name': name, 'source_path': source_path})
+
 @project_app.command("rm")
 def project_rm(
     name: str = typer.Argument(..., help="Project name"),

--- a/tests/commands/test_project_set_source_command.py
+++ b/tests/commands/test_project_set_source_command.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from commands.project import ProjectManager, project as project_cmd
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+def test_set_source_updates_registry_and_config(temp_home, tmp_path):
+    src_old = tmp_path / "src_old"
+    src_old.mkdir()
+    src_new = tmp_path / "src_new"
+    src_new.mkdir()
+
+    manager = ProjectManager()
+    manager.create_project("demo", str(src_old))
+
+    runner = CliRunner()
+    result = runner.invoke(project_cmd, ["set-source", "demo", str(src_new)])
+
+    assert result.exit_code == 0
+    assert "Source path updated" in result.output
+    assert "re-run ingestion" in result.output.lower()
+
+    project_dir = temp_home / ".hound" / "projects" / "demo"
+    config = json.loads((project_dir / "project.json").read_text())
+    assert config["source_path"] == str(src_new.resolve())
+
+    registry_path = temp_home / ".hound" / "projects" / "registry.json"
+    registry = json.loads(registry_path.read_text())
+    assert registry["projects"]["demo"]["source_path"] == str(src_new.resolve())
+
+
+def test_set_source_rejects_missing_path(temp_home, tmp_path):
+    src_old = tmp_path / "old"
+    src_old.mkdir()
+    missing = tmp_path / "missing"
+
+    manager = ProjectManager()
+    manager.create_project("demo", str(src_old))
+
+    runner = CliRunner()
+    result = runner.invoke(project_cmd, ["set-source", "demo", str(missing)])
+
+    assert result.exit_code == 1
+    assert "Source path does not exist" in result.output
+
+    project_dir = temp_home / ".hound" / "projects" / "demo"
+    config = json.loads((project_dir / "project.json").read_text())
+    assert config["source_path"] == str(src_old.resolve())
+
+    registry_path = temp_home / ".hound" / "projects" / "registry.json"
+    registry = json.loads(registry_path.read_text())
+    assert registry["projects"]["demo"]["source_path"] == str(src_old.resolve())


### PR DESCRIPTION
## Summary
- add a ProjectManager.update_source_path helper that updates project.json and registry.json
- expose a new `project set-source` command in both Click and Typer CLIs
- add regression tests covering success and failure cases for updating the source path

## Testing
- pytest tests/commands/test_project_set_source_command.py

------
https://chatgpt.com/codex/tasks/task_e_68d4b9740f8c8325881dd258e634f599